### PR TITLE
Add Gemfile and use latest Minitest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 pkg
 *.swp
+.bundle/
 
 # SWIG Files
 swig/Makefile
@@ -15,6 +16,7 @@ ext/conftest.dSYM/
 ext/mkmf.log
 ext/glpk_wrapper.bundle
 ext/glpk_wrapper.o
+ext/glpk_wrapper.so
 
 # Test Files
 test.lp

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+group :development do
+  gem 'jeweler'
+  gem 'minitest'
+  gem 'rake'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,56 @@
+GEM
+  specs:
+    addressable (2.3.7)
+    builder (3.2.2)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
+    git (1.2.9.1)
+    github_api (0.12.3)
+      addressable (~> 2.3)
+      descendants_tracker (~> 0.0.4)
+      faraday (~> 0.8, < 0.10)
+      hashie (>= 3.3)
+      multi_json (>= 1.7.5, < 2.0)
+      nokogiri (~> 1.6.3)
+      oauth2
+    hashie (3.4.1)
+    highline (1.6.21)
+    jeweler (2.0.1)
+      builder
+      bundler (>= 1.0)
+      git (>= 1.2.5)
+      github_api
+      highline (>= 1.6.15)
+      nokogiri (>= 1.5.10)
+      rake
+      rdoc
+    json (1.8.2)
+    jwt (1.3.0)
+    mini_portile (0.6.2)
+    minitest (5.5.1)
+    multi_json (1.11.0)
+    multi_xml (0.5.5)
+    multipart-post (2.0.0)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    oauth2 (0.9.4)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (~> 1.2)
+    rack (1.6.0)
+    rake (10.4.2)
+    rdoc (4.2.0)
+      json (~> 1.4)
+    thread_safe (0.3.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jeweler
+  minitest
+  rake

--- a/Rakefile
+++ b/Rakefile
@@ -69,3 +69,5 @@ desc "Run Test::Unit tests."
 task :test => :build_extension do
   system("ruby test/test_all.rb")
 end
+
+task :default => [:test]

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,6 @@
 here = File.expand_path(File.dirname(__FILE__))
 
-require 'test/unit'
+require 'minitest/autorun'
 $LOAD_PATH << './ext'
 require here+'/../lib/rglpk'
 

--- a/test/test_basic.rb
+++ b/test/test_basic.rb
@@ -1,6 +1,6 @@
 require File.expand_path('helper', File.dirname(__FILE__))
 
-class TestRglpk < Test::Unit::TestCase
+class TestRglpk < Minitest::Test
 
   def test_create
     assert_instance_of Rglpk::Problem, Rglpk::Problem.new
@@ -24,7 +24,7 @@ class TestRglpk < Test::Unit::TestCase
     assert_equal Rglpk::GLP_MIN, p.obj.dir
     p.obj.dir = Rglpk::GLP_MAX
     assert_equal Rglpk::GLP_MAX, p.obj.dir
-    assert_raise(ArgumentError){p.obj.dir = 3}
+    assert_raises(ArgumentError){p.obj.dir = 3}
   end
 
   def test_add_row
@@ -107,7 +107,7 @@ class TestRglpk < Test::Unit::TestCase
   def test_set_row
     p = Rglpk::Problem.new
     p.add_rows(2)
-    assert_raise(RuntimeError){p.rows[1].set([1, 2])}
+    assert_raises(RuntimeError){p.rows[1].set([1, 2])}
     p.add_cols(2)
     p.rows[1].set([1, 2])
     assert_equal [1, 2], p.rows[1].get
@@ -116,7 +116,7 @@ class TestRglpk < Test::Unit::TestCase
   def test_set_col
     p = Rglpk::Problem.new
     p.add_cols(2)
-    assert_raise(RuntimeError){p.cols[1].set([1, 2])}
+    assert_raises(RuntimeError){p.cols[1].set([1, 2])}
     p.add_rows(2)
     p.cols[1].set([1, 2])
     assert_equal [1, 2], p.cols[1].get

--- a/test/test_brief_example.rb
+++ b/test/test_brief_example.rb
@@ -1,6 +1,6 @@
 require File.expand_path('helper', File.dirname(__FILE__))
 
-class TestBriefExample < Test::Unit::TestCase
+class TestBriefExample < Minitest::Test
   include Examples
   
   def test_brief_example

--- a/test/test_memory_leaks.rb
+++ b/test/test_memory_leaks.rb
@@ -1,6 +1,6 @@
 require File.expand_path('helper', File.dirname(__FILE__))
 
-class TestMemoryLeaks < Test::Unit::TestCase
+class TestMemoryLeaks < Minitest::Test
   include Examples
     
   def test_memory_prof

--- a/test/test_problem_kind.rb
+++ b/test/test_problem_kind.rb
@@ -48,7 +48,7 @@ module TestProblemKind
   end
 end
 
-class BinaryVariables < Test::Unit::TestCase
+class BinaryVariables < Minitest::Test
   include TestProblemKind
   
   def column_kind
@@ -60,7 +60,7 @@ class BinaryVariables < Test::Unit::TestCase
   end
 end
 
-class IntegerVariables < Test::Unit::TestCase
+class IntegerVariables < Minitest::Test
   include TestProblemKind
   
   def column_kind
@@ -72,7 +72,7 @@ class IntegerVariables < Test::Unit::TestCase
   end
 end
 
-class ContinuousVariables < Test::Unit::TestCase
+class ContinuousVariables < Minitest::Test
   include TestProblemKind
   
   def column_kind


### PR DESCRIPTION
It was unclear what testing framework was being used and what version.
I added a `Gemfile` to the project along with the few gems obviously necessary.
This also required a few minor changes to get the tests running again.