### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+cache: bundler
+rvm:
+  - 1.9.3
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y libglpk-dev swig

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/wtaysom/rglpk.svg)](https://travis-ci.org/wtaysom/rglpk)
+
 # Introduction
 
 Rglpk is a package providing a Ruby wrapper to the [GNU GLPK](http://www.gnu.org/software/glpk/) library.  The GLPK (GNU Linear Programming Kit) package is intended for solving large-scale linear programming (LP), mixed integer programming (MIP), and other related problems.


### PR DESCRIPTION
This adds Travis CI integration.
Note that you would have to create an account and enable the Webhook for the badge to work.