### PR TITLE
Allow sparse row coefficient matrices

### DIFF
--- a/lib/rglpk.rb
+++ b/lib/rglpk.rb
@@ -272,17 +272,22 @@ module Rglpk
       [t, lb, ub]
     end
     
-    def set(v)
-      raise RuntimeError unless v.size == @p.cols.size
+    def set(v, i = nil)
+      raise RuntimeError unless v.size == @p.cols.size or (not i.nil? and i.size == v.size)
       ind = Glpk_wrapper.new_intArray(v.size + 1)
       val = Glpk_wrapper.new_doubleArray(v.size + 1)
       
-      1.upto(v.size){|x| Glpk_wrapper.intArray_setitem(ind, x, x)}
+      if i.nil?
+        i = 1.upto(v.size)
+      end
+
+      i.each_with_index{|x, y|
+        Glpk_wrapper.intArray_setitem(ind, y + 1, x)}
       v.each_with_index{|x, y|
         Glpk_wrapper.doubleArray_setitem(val, y + 1, x)}
-      
+
       Glpk_wrapper.glp_set_mat_row(@p.lp, @i, v.size, ind, val)
-      
+
       Glpk_wrapper.delete_intArray(ind)
       Glpk_wrapper.delete_doubleArray(val)
     end

--- a/test/test_basic.rb
+++ b/test/test_basic.rb
@@ -200,6 +200,18 @@ class TestRglpk < Minitest::Test
     p.simplex({:msg_lev => 1})
   end
 
+  def test_sparse_row
+    p = Rglpk::Problem.new
+    p.add_cols(7)
+    rows = p.add_rows(3)
+    rows[0].set [1], [5]
+    rows[1].set [3, 6], [6, 7]
+    rows[2].set [1, 2, 3], [4, 5, 7]
+    assert_equal [0, 0, 0, 0, 1, 0, 0], rows[0].get
+    assert_equal [0, 0, 0, 0, 0, 3, 6], rows[1].get
+    assert_equal [0, 0, 0, 1, 2, 0, 3], rows[2].get
+  end
+
   class D < Rglpk::Problem
     attr_accessor :species
     def initialize


### PR DESCRIPTION
The GLPK API allows this, so expose this functionality in a backwards-compatible way.