### PR TITLE
Expose glp_mip_row_val

### DIFF
--- a/lib/rglpk.rb
+++ b/lib/rglpk.rb
@@ -314,7 +314,11 @@ module Rglpk
     def get_prim
       Glpk_wrapper.glp_get_row_prim(@p.lp, @i)
     end
-    
+
+    def mip_val
+      Glpk_wrapper.glp_mip_row_val(@p.lp, @i)
+    end
+
     def get_dual
       Glpk_wrapper.glp_get_row_dual(@p.lp, @i)
     end

--- a/test/test_problem_kind.rb
+++ b/test/test_problem_kind.rb
@@ -45,6 +45,10 @@ module TestProblemKind
     @p.cols.each_with_index do |col, index|
       assert_equal results[index], col.send(value_method)
     end
+
+    @p.rows.each do |row|
+      refute_nil row.send(value_method)
+    end
   end
 end
 


### PR DESCRIPTION
`glp_get_row_prim` is exposed (for linear optimisations), but not `glp_mip_row_val` (the analogue for integer optimisations).
